### PR TITLE
fix signature verification when DKIM-Signature b= param ends in ;

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -248,7 +248,7 @@ func signatureBase(r io.ReadSeeker, s *Signature) (sig *Signature, msg, dkimhead
 
 }
 
-var bRE = regexp.MustCompile("b=.+($|;)")
+var bRE = regexp.MustCompile("b=[^;]+")
 
 func SignedHeader(s Signature, r io.ReadSeeker, dst io.Writer, key *rsa.PrivateKey, nl string) error {
 	if nl != "\n" {


### PR DESCRIPTION
Previously, the code relied on the fact that the b= parameter typically comes
last in the DKIM-Signature header, and some (many? most?) implementations leave
off the trailing semicolon in that situation.

However, at least the github.com/emersion/go-msgauth Go package generates
DKIM-Signature headers where the last parameter includes the trailing semicolon:

    DKIM-Signature: […] b=foo;

Without this change, bRE matches the trailing semicolon, too, and removes
it. This results in incorrectly failing verification of otherwise valid DKIM
signatures (verified on dkimvalidator.com, outlook and gmail).